### PR TITLE
Reinstall when version is different

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,12 +5,21 @@
   register: go_version_result
   changed_when: false
 
+- name: Remove current installation.
+  file:
+    state: absent
+    path: /usr/local/go
+  when:
+    - go_version_result is succeeded
+    - go_version not in go_version_result.stdout
+
 - name: Download Go.
   get_url:
     url: "{{ go_download_url }}"
     dest: /usr/local/src/{{ go_tarball }}
     checksum: "sha256:{{ go_checksum }}"
   when: go_version_result is failed
+        or go_version not in go_version_result.stdout
 
 - name: Extract Go.
   unarchive:
@@ -18,6 +27,7 @@
     dest: /usr/local
     copy: no
   when: go_version_result is failed
+        or go_version not in go_version_result.stdout
 
 - name: Add Go to to system-wide $PATH.
   copy:


### PR DESCRIPTION
Remove the current installation and install the version specified when the installed version doesn't match go_version.